### PR TITLE
automatically deploy tidb cluster via script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target_servers/*
 ./run
 __pycache__
 servers.txt
+topology.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target_servers/*
 **/venv/*
 ./run
 __pycache__
+servers.txt

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ SET PASSWORD='secure-password';
 
 # e.g. ./day0.sh example.com 3 1 # means deploy 3 servers, all at once (100% in parallel)
 # Note: It takes about 10 minutes to complete 5 servers
-```
 
 ## Destroy everything
 This will destroy all servers, volumes and DNS records.

--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ SET PASSWORD='secure-password';
 ./day0.sh <domain> <number-of-servers> <percent-at-once>
 ```
 
-# e.g. ./day0.sh example.com 3 1 # means deploy 3 servers, all at once (100% in parallel)
-# Note: It takes about 10 minutes to complete 5 servers
+#### e.g. ./day0.sh example.com 3 1 # means deploy 3 servers, all at once (100% in parallel)
+
+> Note: It takes about 10 minutes to complete 5 servers
 
 ## Destroy everything
+
 This will destroy all servers, volumes and DNS records.
 ```
 ./destroy-all.sh

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ This will deploy a three node TiDB database cluster.
 # Read then execute
 ./provision-database.sh
 ```
-
-> Note after server creation you manually need to create `topology.yaml` see example: [pr](https://github.com/KarmaComputing/high-availability-web-services/pull/7) the ip addresses you need are in `servers.txt` after server creation, and also visible on the cloud console (if using Hetzner), then run `provision-database.sh` again. It's expected during testing/day0 to use `destroy-all.sh` to easily destroy and start again for speed and validation of the process.
+> Note: The password to the database cluster is randomly generated and printed at the end of installation.
 
 #### Set database cluster password
 Set the database cluster password by ssh connection to the first node in `servers.txt`,
@@ -260,3 +259,5 @@ https://www.reddit.com/r/shortcuts/comments/9u57kr/comment/e91ogm4/?utm_source=s
 https://askubuntu.com/questions/77352/need-help-with-bash-checking-if-computer-uptime-is-greater-than-5-minutes
 https://unix.stackexchange.com/questions/87405/how-can-i-execute-local-script-on-remote-machine-and-include-arguments
 https://stackoverflow.com/questions/43235179/how-to-execute-ssh-keygen-without-prompt/45031320
+https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
+https://stackoverflow.com/questions/2556190/random-number-from-a-range-in-a-bash-script

--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ Day0 is a script which creates servers and configures them.
 
 ### Deploy database (tidb)
 
-This will deploy a three node TiDB database cluster
+This will deploy a three node TiDB database cluster.
 
 ```
 # Read then execute
 ./provision-database.sh
 ```
+
+> Note after server creation you manually need to create `topology.yaml` see example: [pr](https://github.com/KarmaComputing/high-availability-web-services/pull/7) the ip addresses you need are in `servers.txt` after server creation, and also visible on the cloud console (if using Hetzner), then run `provision-database.sh` again. It's expected during testing/day0 to use `destroy-all.sh` to easily destroy and start again for speed and validation of the process.
+
 #### Set database cluster password
 Set the database cluster password by ssh connection to the first node in `servers.txt`,
 then `mysql -h 127.0.0.1 -u root -P 4000`, and set a password with:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ To handle that, we monitor at the DNS level to remove dead endpoints, and lean o
 
 ## Set .env settings
 
+1. Get an API key from your cloud provider (e.g. Hetzner)
+2. Get an API key from your DNS provider (e.g CloudNS)
+3. Decide which domain name you want to deploy to (e.g. example.com)
+
 Copy `.env.example` to `.env` and add change to your own settings:
 
 - DOMAIN=example.co.uk

--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ To handle that, we monitor at the DNS level to remove dead endpoints, and lean o
 
 - Creates servers
 - Configures DNS
-- Installs everything on all servers
+- Installs web & database across all servers
 ```
+# Deploy database (tidb)
+./provision-database.sh
+# Deploy web stack (apache & uwsgi)
 ./day0.sh <domain> <number-of-servers> <percent-at-once>
 # e.g. ./day0.sh example.com 3 1 # means deploy 3 servers, all at once (100% in parallel)
 # Note: It takes about 10 minutes to complete 5 servers
@@ -192,3 +195,4 @@ https://superuser.com/questions/968561/how-to-get-the-machine-ip-address-in-a-sy
 https://unix.stackexchange.com/a/167040
 https://www.reddit.com/r/shortcuts/comments/9u57kr/comment/e91ogm4/?utm_source=share&utm_medium=web2x&context=3
 https://askubuntu.com/questions/77352/need-help-with-bash-checking-if-computer-uptime-is-greater-than-5-minutes
+https://unix.stackexchange.com/questions/87405/how-can-i-execute-local-script-on-remote-machine-and-include-arguments

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ This will deploy a three node TiDB database cluster.
 
 ```
 # Read then execute
+# Turn on debug mode (optional)
+export DEBUG_MODE=true
+# Provision database:
 ./provision-database.sh
 ```
 > Note: The password to the database cluster is randomly generated and printed at the end of installation.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Vultr is in progress.
 
 ## Run (~automated) Day 0 install and provision database scripts
 
-Day0 is a script which creates servers and configures them:
+`day0.sh` is a script which creates web application servers and configures them:
 
 - Creates servers/"instances"
 - Configures DNS & healthchecks (failed nodes automatically stop being announced)

--- a/destroy-all.sh
+++ b/destroy-all.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 ./dns/delete-all-wildcards.sh
 ./dns/delete-all-a-records-for-each-server.sh
+./hetzner/hetzner-delete-all-volumes.sh
 ./hetzner/hetzner-delete-all-servers.sh

--- a/hetzner/hetzner-attach-volumes.sh
+++ b/hetzner/hetzner-attach-volumes.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -x
+export $(xargs <.env)
+
+curl \
+  -v -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+  'https://api.hetzner.cloud/v1/servers' > hetzner-servers.json
+
+VOLUME_IDS=$(./hetzner/hetzner-get-all-volume-ids.sh > hetzner-volume-ids.txt)
+
+NUM_LOOPS=$(wc -l < hetzner-volume-ids.txt)
+
+cat hetzner-servers.json | jq -r '.servers[]| {id} | join("")' > hetzner-server-ids.txt
+for i in $(seq 1 $NUM_LOOPS);
+do
+  # Get line n of the hetzner-server-ids.txt
+  SERVER_ID=$(sed -n "$i"p hetzner-server-ids.txt)
+  VOLUME_ID=$(sed -n "$i"p hetzner-volume-ids.txt)
+  echo "attaching VOLUME_ID $VOLUME_ID to SERVER_ID: $SERVER_ID"
+
+  curl \
+    -X POST \
+    -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"automount":true,"server":"'$SERVER_ID'"}' \
+    "https://api.hetzner.cloud/v1/volumes/$VOLUME_ID/actions/attach"
+done
+

--- a/hetzner/hetzner-create-n-servers.sh
+++ b/hetzner/hetzner-create-n-servers.sh
@@ -20,6 +20,15 @@ fi
 DATACENTER=nbg1-dc3
 
 
+SERVERS_FILENAME=servers.txt
+if [[ $CALLING_SCRIPT =~ "provision-database.sh" ]]; then
+  SERVERS_FILENAME=db-servers.txt
+fi
+
+# Remove any blank lines from SERVERS_FILENAME
+sed -i '/^$/d' $SERVERS_FILENAME
+
+
 for INDEX in $(seq $NUMBER_OF_SERVERS)
 do
   echo Creating server $n
@@ -30,6 +39,8 @@ do
     -H "Content-Type: application/json" \
     -d '{"automount":false,"datacenter":"nbg1-dc3","firewalls":[],"image":"ubuntu-20.04","labels":{}, "name":"'$SERVER_NAME'","networks":[],"server_type":"'$SERVER_TYPE'","ssh_keys":["chris@chris-ideapad","joel@ubuntu"],"start_after_create":true,"user_data":"","volumes":[]}' \
     'https://api.hetzner.cloud/v1/servers' > new-server.json
+    NEW_SERVER_IP=$(cat new-server.json | jq -r .server.public_net.ipv4.ip)
+    echo $NEW_SERVER_IP >> $SERVERS_FILENAME
 done
 
 echo $INDEX servers created

--- a/hetzner/hetzner-create-n-volumes.sh
+++ b/hetzner/hetzner-create-n-volumes.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -x
+export $(xargs <.env)
+
+# Usage: ./hetzner/hetzner-create-n-volumes.sh 3 cx11
+# Note: Server type must be in lowercase
+
+# Create n hetzner volumes
+NUMBER_OF_VOLUMES=$1
+VOLUME_SIZE=$2
+
+if [[ $# -ne 2 ]]
+then
+  echo "Usage: hetzner-create-n-volumes.sh <number of volumes> <size>"
+  exit 255
+fi
+
+
+DATACENTER=nbg1-dc3
+
+for INDEX in $(seq $NUMBER_OF_VOLUMES)
+do
+  echo Creating volume $n
+  VOLUME_NAME=$(cat /proc/sys/kernel/random/uuid)
+
+  curl \
+    -X POST \
+    -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"automount":false,"format":"ext4","location":"nbg1","name":"'$VOLUME_NAME'","size":"'$VOLUME_SIZE'"}' \
+    'https://api.hetzner.cloud/v1/volumes'
+done
+
+echo $INDEX volumes created
+
+
+
+

--- a/hetzner/hetzner-create-n-volumes.sh
+++ b/hetzner/hetzner-create-n-volumes.sh
@@ -3,7 +3,7 @@
 set -x
 export $(xargs <.env)
 
-# Usage: ./hetzner/hetzner-create-n-volumes.sh 3 cx11
+# Usage: ./hetzner/hetzner-create-n-volumes.sh 3 10
 # Note: Server type must be in lowercase
 
 # Create n hetzner volumes

--- a/hetzner/hetzner-delete-all-volumes.sh
+++ b/hetzner/hetzner-delete-all-volumes.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+
+# WARNING DANGER: Deletes all volumes in given API_TOKEN project
+
+export $(xargs <.env)
+
+curl \
+	-H "Authorization: Bearer $HETZNER_API_TOKEN" \
+	'https://api.hetzner.cloud/v1/volumes' > hetzner-volumes.json
+
+VOLUME_IDS=$(cat hetzner-volumes.json | jq -r '.volumes[]| {id} | join("")')
+
+for VOLUME_ID in $VOLUME_IDS;
+do
+  echo "Detatching VOLUME_ID: $VOLUME_ID"
+  curl \
+    -X POST \
+    -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+    "https://api.hetzner.cloud/v1/volumes/$VOLUME_ID/actions/detach"
+  sleep 2
+
+  echo "Deleting VOLUME_ID: $VOLUME_ID"
+  curl \
+  	-X DELETE \
+  	-H "Authorization: Bearer $HETZNER_API_TOKEN" \
+  	-H "Content-Type: application/json" \
+  	"https://api.hetzner.cloud/v1/volumes/$VOLUME_ID"
+done
+

--- a/hetzner/hetzner-get-all-servers-ip-public-net.sh
+++ b/hetzner/hetzner-get-all-servers-ip-public-net.sh
@@ -2,8 +2,6 @@
 
 set -x
 
-# WARNING DANGER: Deletes all data on all servers and rebuild them.
-
 export $(xargs <.env)
 
 curl \

--- a/hetzner/hetzner-get-all-volume-ids.sh
+++ b/hetzner/hetzner-get-all-volume-ids.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+export $(xargs <.env)
+
+curl \
+    --silent \
+      -H "Authorization: Bearer $HETZNER_API_TOKEN" \
+        'https://api.hetzner.cloud/v1/volumes' | jq -r '.volumes[].id'
+

--- a/hetzner/hetzner-set-volume-mount-options.sh
+++ b/hetzner/hetzner-set-volume-mount-options.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -x
+
+# For each Hetzner server configure the first
+# volume /etc/fstab options to be
+# valid for TiDB.
+# See https://docs.pingcap.com/tidb/stable/check-before-deployment
+
+umount /dev/sdb
+mkdir -p /mnt/data1
+sed -r -i 's/(.*by-id\/scsi-0HC_Volume.*\/)(.*).*/\1\data1 ext4 defaults,nodelalloc,noatime,nofail 0 0/p' /etc/fstab
+
+cat /etc/fstab | uniq > /etc/fstab.new && cp /etc/fstab.new /etc/fstab 
+
+# -r flag tells sed to use extended regular expressions
+# The brackets () are a match group, there is only one match group,
+# Which is printed by /1 (if there was a seccond match group, then
+# there would be \2 to print it)
+# Not the characters .* after the () brackets is *not* a regex, it 
+# explicitly tells sed that we want to ignore any number of any type 
+# of characters between the defined groups
+# -i flag performs edits the file directly
+# See: https://www.ryanchapin.com/using-sed-with-regex-capture-groups/
+
+mount -a
+mount -t ext4

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -50,7 +50,7 @@ do
 done
 sleep 35
 # Install TiUP on first node
-.tidb/generate-tidb-topology.sh > topology.yaml
+./tidb/generate-tidb-topology.sh > ./topology.yaml
 scp topology.yaml root@$(sed -n 1p db-servers.txt):~
 ssh root@$(sed -n 1p db-servers.txt) -C "curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh"
 ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster"
@@ -77,3 +77,6 @@ ssh root@$(sed -n 1p db-servers.txt) -C "apt-get install -y mysql-client"
 ssh root@$(sed -n 1p db-servers.txt) -C "mysql -h 127.0.0.1 -P 4000 -e 'SELECT NOW()'"
 # Set password: 
 echo Important: Set password now. Connect to cluster and issue e.g. SET PASSWORD='secret'
+
+echo "Connect to the database cluster e.g."
+echo "mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt)"

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -52,7 +52,7 @@ sleep 35
 # Install TiUP on first node
 .tidb/generate-tidb-topology.sh > topology.yaml
 scp topology.yaml root@$(sed -n 1p db-servers.txt):~
-ssh root@$(sed -n 1p servers.txt) -C "curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh"
+ssh root@$(sed -n 1p db-servers.txt) -C "curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh"
 ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster"
 ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup update --self && tiup update cluster"
 ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup --binary cluster"

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -8,8 +8,10 @@ else
   set -x
 fi
 
+rm -f db-servers.txt
+touch db-servers.txt
+
 ./hetzner/hetzner-create-n-servers.sh 3 cpx11
-./hetzner/hetzner-get-all-servers-ip-public-net.sh > db-servers.txt
 
 sleep 5
 

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -78,5 +78,11 @@ ssh root@$(sed -n 1p db-servers.txt) -C "mysql -h 127.0.0.1 -P 4000 -e 'SELECT N
 # Set password: 
 echo Important: Set password now. Connect to cluster and issue e.g. SET PASSWORD='secret'
 
+echo Setting randomly generated password for database cluster
+DB_PASSWORD_LENGTH=$(shuf -i 25-65 -n 1)
+DB_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c $DB_PASSWORD_LENGTH; echo '')
+
+mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt) -e "SET PASSWORD='$(tr -dc A-Za-z0-9 </dev/urandom | head -c 25 ; echo '')'"
 echo "Connect to the database cluster e.g."
-echo "mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt)"
+echo "mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt)" -p
+echo The DB_PASSWORD is: $DB_PASSWORD

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-set -x
+
+if [ -z $DEBUG_MODE ]
+then
+  set +x
+else
+  echo Turning on debug mode
+  set -x
+fi
 
 ./hetzner/hetzner-create-n-servers.sh 3 cpx11
 ./hetzner/hetzner-get-all-servers-ip-public-net.sh > db-servers.txt

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-./hetzner/hetzner-create-n-servers.sh 3
+./hetzner/hetzner-create-n-servers.sh 3 cpx11
 ./hetzner/hetzner-get-all-servers-ip-public-net.sh > servers.txt
 
 sleep 5
@@ -13,10 +13,26 @@ sleep 15
 echo Attach one of each volume to each of the servers
 ./hetzner/hetzner-attach-volumes.sh
 
+# Generate keys to bootstrap Tidb cluster
+ssh-keygen -f id_rsa -N "" <<< y
+
 for SERVER in $(cat servers.txt)
 do
+  ssh root@$SERVER apt update
+  echo Copy key for bootstraping Tidb cluster
+  scp id_rsa* root@$SERVER:/root/.ssh
+  ssh root@$SERVER tee -a .ssh/authorized_keys < id_rsa.pub
+  for TARGET in $(cat servers.txt)
+  do
+    ssh root@$TARGET -C "ssh-keyscan -H $TARGET >> ~/.ssh/known_hosts"
+  done
+  
   # configure fstab mount options
   ssh root@$SERVER "bash -s" -- < ./hetzner/hetzner-set-volume-mount-options.sh
+  # Configure sysctl
+  ssh root@$SERVER "bash -s" -- < ./sysctl/set-sysctl.sh
+  # Configure /etc/security/limits.conf
+  ssh root@$SERVER "bash -s" -- < ./limits/set-limits.sh
   ssh root@$SERVER 'echo "vm.swappiness = 0">> /etc/sysctl.conf && swapoff -a && swapon -a && sysctl -p'
 
   scp systemd/system/disable-transparent-huge-pages.service root@$SERVER:/etc/systemd/system/disable-transparent-huge-pages.service
@@ -25,5 +41,37 @@ do
   ssh root@$SERVER systemctl enable disable-transparent-huge-pages
   # Verify huge pages off
   ssh root@$SERVER cat /sys/kernel/mm/transparent_hugepage/enabled
+  # Enable & start irqbalance
+  ssh root@$SERVER systemctl start irqbalance
+  ssh root@$SERVER systemctl enable irqbalance
+  # Install numactl
+  ssh root@$SERVER apt install numactl
+  ssh root@$SERVER reboot
 done
-
+sleep 35
+# Install TiUP on first node
+scp topology.yaml root@$(sed -n 1p servers.txt):~
+ssh root@$(sed -n 1p servers.txt) -C "curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh"
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster"
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup update --self && tiup update cluster"
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup --binary cluster"
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster check ./topology.yaml"
+RETURN_CODE=$?
+if [ $RETURN_CODE -ne 0 ]
+then
+  echo Did not pass tiup cluster check, refusing to install
+  exit 255
+fi
+# Deploy TiDB cluster
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster deploy tidb-database v5.3.0 ./topology.yaml <<< y" #auto confirm yes
+# Start the TiDB cluster
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster start tidb-database"
+# List the clusters (we only created one)
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster list"
+# Show status of cluster
+ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster display tidb-database"
+# Install mysql-client (for testing only)
+ssh root@$(sed -n 1p servers.txt) -C "apt-get install -y mysql-client"
+# Verify mysql protocol and Tidb
+ssh root@$(sed -n 1p servers.txt) -C "mysql -h 127.0.0.1 -P 4000 -e 'SELECT NOW()'"
+# Set password: 

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -x
+
+./hetzner/hetzner-create-n-servers.sh 3
+./hetzner/hetzner-get-all-servers-ip-public-net.sh > servers.txt
+
+sleep 5
+
+# Create 3 volumes each with 10gb each
+./hetzner/hetzner-create-n-volumes.sh 3 10
+sleep 15
+
+echo Attach one of each volume to each of the servers
+./hetzner/hetzner-attach-volumes.sh
+
+for SERVER in $(cat servers.txt)
+do
+  # configure fstab mount options
+  ssh root@$SERVER "bash -s" -- < ./hetzner/hetzner-set-volume-mount-options.sh
+  ssh root@$SERVER 'echo "vm.swappiness = 0">> /etc/sysctl.conf && swapoff -a && swapon -a && sysctl -p'
+
+  scp systemd/system/disable-transparent-huge-pages.service root@$SERVER:/etc/systemd/system/disable-transparent-huge-pages.service
+  ssh root@$SERVER systemctl daemon-reload
+  ssh root@$SERVER systemctl start disable-transparent-huge-pages
+  ssh root@$SERVER systemctl enable disable-transparent-huge-pages
+  # Verify huge pages off
+  ssh root@$SERVER cat /sys/kernel/mm/transparent_hugepage/enabled
+done
+

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -82,7 +82,7 @@ echo Setting randomly generated password for database cluster
 DB_PASSWORD_LENGTH=$(shuf -i 25-65 -n 1)
 DB_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c $DB_PASSWORD_LENGTH; echo '')
 
-mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt) -e "SET PASSWORD='$(tr -dc A-Za-z0-9 </dev/urandom | head -c 25 ; echo '')'"
-echo "Connect to the database cluster e.g."
+mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt) -e "SET PASSWORD='$DB_PASSWORD')'"
+echo "Connect to the database cluster:"
 echo "mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt)" -p
 echo The DB_PASSWORD is: $DB_PASSWORD

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -89,7 +89,7 @@ echo Setting randomly generated password for database cluster
 DB_PASSWORD_LENGTH=$(shuf -i 25-65 -n 1)
 DB_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c $DB_PASSWORD_LENGTH; echo '')
 
-mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt) -e "SET PASSWORD='$DB_PASSWORD')'"
+mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt) -e "SET PASSWORD='$DB_PASSWORD'"
 echo "Connect to the database cluster:"
 echo "mysql -u root -P 4000 -h $(sed -n 1p db-servers.txt)" -p
 echo The DB_PASSWORD is: $DB_PASSWORD

--- a/provision-database.sh
+++ b/provision-database.sh
@@ -2,7 +2,7 @@
 set -x
 
 ./hetzner/hetzner-create-n-servers.sh 3 cpx11
-./hetzner/hetzner-get-all-servers-ip-public-net.sh > servers.txt
+./hetzner/hetzner-get-all-servers-ip-public-net.sh > db-servers.txt
 
 sleep 5
 
@@ -16,13 +16,13 @@ echo Attach one of each volume to each of the servers
 # Generate keys to bootstrap Tidb cluster
 ssh-keygen -f id_rsa -N "" <<< y
 
-for SERVER in $(cat servers.txt)
+for SERVER in $(cat db-servers.txt)
 do
   ssh root@$SERVER apt update
   echo Copy key for bootstraping Tidb cluster
   scp id_rsa* root@$SERVER:/root/.ssh
   ssh root@$SERVER tee -a .ssh/authorized_keys < id_rsa.pub
-  for TARGET in $(cat servers.txt)
+  for TARGET in $(cat db-servers.txt)
   do
     ssh root@$TARGET -C "ssh-keyscan -H $TARGET >> ~/.ssh/known_hosts"
   done
@@ -50,12 +50,13 @@ do
 done
 sleep 35
 # Install TiUP on first node
-scp topology.yaml root@$(sed -n 1p servers.txt):~
+.tidb/generate-tidb-topology.sh > topology.yaml
+scp topology.yaml root@$(sed -n 1p db-servers.txt):~
 ssh root@$(sed -n 1p servers.txt) -C "curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh"
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster"
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup update --self && tiup update cluster"
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup --binary cluster"
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster check ./topology.yaml"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup update --self && tiup update cluster"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup --binary cluster"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster check ./topology.yaml"
 RETURN_CODE=$?
 if [ $RETURN_CODE -ne 0 ]
 then
@@ -63,15 +64,16 @@ then
   exit 255
 fi
 # Deploy TiDB cluster
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster deploy tidb-database v5.3.0 ./topology.yaml <<< y" #auto confirm yes
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster deploy tidb-database v5.3.0 ./topology.yaml <<< y" #auto confirm yes
 # Start the TiDB cluster
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster start tidb-database"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster start tidb-database"
 # List the clusters (we only created one)
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster list"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster list"
 # Show status of cluster
-ssh root@$(sed -n 1p servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster display tidb-database"
+ssh root@$(sed -n 1p db-servers.txt) -C "export PATH=/root/.tiup/bin:$PATH && tiup cluster display tidb-database"
 # Install mysql-client (for testing only)
-ssh root@$(sed -n 1p servers.txt) -C "apt-get install -y mysql-client"
+ssh root@$(sed -n 1p db-servers.txt) -C "apt-get install -y mysql-client"
 # Verify mysql protocol and Tidb
-ssh root@$(sed -n 1p servers.txt) -C "mysql -h 127.0.0.1 -P 4000 -e 'SELECT NOW()'"
+ssh root@$(sed -n 1p db-servers.txt) -C "mysql -h 127.0.0.1 -P 4000 -e 'SELECT NOW()'"
 # Set password: 
+echo Important: Set password now. Connect to cluster and issue e.g. SET PASSWORD='secret'

--- a/servers.txt
+++ b/servers.txt
@@ -1,6 +1,0 @@
-server-a.example.co.uk
-server-b.example.co.uk
-server-c.example.co.uk
-server-d.example.co.uk
-server-e.example.co.uk
-server-f.example.co.uk

--- a/systemd/system/disable-transparent-huge-pages.service
+++ b/systemd/system/disable-transparent-huge-pages.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Disable Transparent Huge Pages (THP)
+DefaultDependencies=no
+After=sysinit.target local-fs.target
+Before=mongod.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo never | tee /sys/kernel/mm/transparent_hugepage/enabled > /dev/null'
+
+[Install]
+WantedBy=basic.target
+

--- a/systemd/system/disable-transparent-huge-pages.service
+++ b/systemd/system/disable-transparent-huge-pages.service
@@ -6,6 +6,7 @@ After=sysinit.target local-fs.target
 [Service]
 Type=oneshot
 ExecStart=/bin/sh -c 'echo never | tee /sys/kernel/mm/transparent_hugepage/enabled > /dev/null'
+ExecStart=/bin/sh -c 'echo never | tee /sys/kernel/mm/transparent_hugepage/defrag > /dev/null'
 
 [Install]
 WantedBy=basic.target

--- a/systemd/system/disable-transparent-huge-pages.service
+++ b/systemd/system/disable-transparent-huge-pages.service
@@ -2,7 +2,6 @@
 Description=Disable Transparent Huge Pages (THP)
 DefaultDependencies=no
 After=sysinit.target local-fs.target
-Before=mongod.service
 
 [Service]
 Type=oneshot

--- a/tidb/generate-tidb-topology.sh
+++ b/tidb/generate-tidb-topology.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Generates TiDB topology yaml
+# See https://docs.pingcap.com/tidb/v5.3/hybrid-deployment-topology
+
+DB_SERVERS=$(cat ../db-servers.txt)
+
+function list_first_server {
+  FIRST_SERVER=$(sed -n 1p ../db-servers.txt)
+echo "  - host: $FIRST_SERVER"
+}
+
+function list_servers {
+for DB_SERVER in $DB_SERVERS
+do
+echo "  - host: $DB_SERVER"
+done
+}
+
+echo "global:"
+echo "  user: 'tidb'"
+echo "  ssh_port: 22"
+echo "  deploy_dir: '/mnt/data1/tidb-deploy'"
+echo "  data_dir: '/mnt/data1/tidb-data'"
+echo "server_configs: {}"
+echo "pd_servers:"
+list_servers
+echo
+echo "tidb_servers:"
+list_servers
+echo "tikv_servers:"
+list_servers
+echo "monitoring_servers:"
+list_first_server
+echo "grafana_servers:"
+list_first_server
+echo "alertmanager_servers:"
+list_first_server

--- a/tidb/generate-tidb-topology.sh
+++ b/tidb/generate-tidb-topology.sh
@@ -3,10 +3,10 @@
 # Generates TiDB topology yaml
 # See https://docs.pingcap.com/tidb/v5.3/hybrid-deployment-topology
 
-DB_SERVERS=$(cat ../db-servers.txt)
+DB_SERVERS=$(cat ./db-servers.txt)
 
 function list_first_server {
-  FIRST_SERVER=$(sed -n 1p ../db-servers.txt)
+  FIRST_SERVER=$(sed -n 1p ./db-servers.txt)
 echo "  - host: $FIRST_SERVER"
 }
 


### PR DESCRIPTION
Ref #4 

This will create and configure servers ready for TiDB, and then installs TiDB. 

- TODO: generate topology.yaml from servers.txt.

## How to test this and deploy TiDB

See [updated readme](https://github.com/KarmaComputing/high-availability-web-services/tree/4-tidb#deploy-database-tidb)


example topology,yaml: (containers all server ups from servers.txt - yours will be different just an example)

See [tidb architecture](https://docs.pingcap.com/tidb/stable/tidb-architecture) for explanation of pd  vs tikv:

```
global:
  user: "tidb"
  ssh_port: 22
  deploy_dir: "/mnt/data1/tidb-deploy"
  data_dir: "/mnt/data1/tidb-data"
server_configs: {}
pd_servers:
  - host: 116.203.85.233
  - host: 116.203.96.37
  - host: 94.130.230.64

tidb_servers:
  - host: 116.203.85.233
  - host: 116.203.96.37
  - host: 94.130.230.64
tikv_servers:
  - host: 116.203.85.233
  - host: 116.203.96.37
  - host: 94.130.230.64
monitoring_servers:
  - host: 116.203.85.233
grafana_servers:
  - host: 116.203.85.233
alertmanager_servers:
  - host: 116.203.85.233
```

# How to destroy to save costs (database instances do not currently auto self destruct)

Warning this will destroy everything, including web nodes

> Warning be sure to check the API key is for an **experimental** project.
```
./destroy-all.sh
```